### PR TITLE
Handle null results in Map

### DIFF
--- a/Optional.Tests/Optional_Tests.cs
+++ b/Optional.Tests/Optional_Tests.cs
@@ -49,8 +49,12 @@ namespace Optional.Tests
             Assert.True(stringOpt.HasValue);
             Assert.Equal(stringOpt.Value, "123");
 
+            var nullMap = opt.Map<string>(val => null);
+            Assert.False(nullMap.HasValue);
+            Assert.Equal(nullMap.GetHashCode(), Optional.Empty<string>().GetHashCode());
+
             Assert.Equal( opt.Filter( val => (val == 123) ),  Optional.FromValue(123) );
-            Assert.Equal( opt.Filter( val => (val == 456) ),  Optional.Empty<int>() );            
+            Assert.Equal( opt.Filter( val => (val == 456) ),  Optional.Empty<int>() );
         }
 
         [Fact]

--- a/Optional/Optional.cs
+++ b/Optional/Optional.cs
@@ -127,6 +127,10 @@ namespace Optional
                 return Optional.Empty<U>();
             }
             var newValue = transform(_value);
+            if(object.Equals(newValue, null))
+            {
+                return Optional.Empty<U>();
+            }
             return new Optional<U>( newValue, true);
         }
 


### PR DESCRIPTION
## Summary
- ensure Optional.Map returns empty when the mapping function yields null
- add regression test for mapping null and hash code safety

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab15fe175883278bcf0856b886f7d6