### PR TITLE
Handle null mapping for reference types

### DIFF
--- a/Optional.Tests/Optional_Tests.cs
+++ b/Optional.Tests/Optional_Tests.cs
@@ -84,5 +84,13 @@ namespace Optional.Tests
         // Map
         // FlatMap
 
+        [Fact]
+        public void MapToNullReferenceProducesEmptyOptional()
+        {
+            var opt = Optional.From("abc");
+            var result = opt.Map<string>(s => null);
+            Assert.False(result.HasValue);
+        }
+
     }
 }

--- a/Optional/Optional.cs
+++ b/Optional/Optional.cs
@@ -127,11 +127,11 @@ namespace Optional
                 return Optional.Empty<U>();
             }
             var newValue = transform(_value);
-            if(object.Equals(newValue, null))
+            if(newValue == null && !typeof(U).IsValueType)
             {
                 return Optional.Empty<U>();
             }
-            return new Optional<U>( newValue, true);
+            return new Optional<U>(newValue, true);
         }
 
         public override bool Equals (object obj)


### PR DESCRIPTION
## Summary
- Ensure Optional.Map returns an empty optional when the mapping function yields null for reference types
- Add unit test to verify mapping to null produces an empty Optional

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab56529a9c832786364ea8913f98b9